### PR TITLE
Add SKU helpers, profit metrics, and dev diagnostics

### DIFF
--- a/StellaVisionMG_EXE_PATCH2_FIXED/StellaVisionMG/README.txt
+++ b/StellaVisionMG_EXE_PATCH2_FIXED/StellaVisionMG/README.txt
@@ -1,0 +1,6 @@
+Atualizações principais
+-----------------------
+- O bloco final `if __name__ == "__main__":` em `app.py` foi substituído pelo snippet solicitado, garantindo execução padrão na porta 5001.
+- Os helpers de SKU (`_slug`, `_build_prefix`, `_next_seq`), o `get_db` e a rota `/dev/sku` foram adicionados em `app.py`, próximos ao topo do arquivo, logo após as migrações e antes das rotas.
+- Os templates existentes permaneceram inalterados; o back-end apenas passou `rows`, `chart_labels` e `chart_values` para `dashboard.html`.
+- Para iniciar na porta 5001 utilize `export PORT=5001 && python app.py` (Linux/macOS) ou `set PORT=5001 && python app.py` (Windows).

--- a/StellaVisionMG_EXE_PATCH2_FIXED/StellaVisionMG/init_db.py
+++ b/StellaVisionMG_EXE_PATCH2_FIXED/StellaVisionMG/init_db.py
@@ -79,7 +79,7 @@ CREATE TABLE IF NOT EXISTS stock_moves(
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   data TEXT, product_id INTEGER, tipo TEXT CHECK(tipo IN ('IN','OUT')),
   qtde INTEGER,
-  origem TEXT CHECK(origem IN ('compra','venda','ajuste','rma_retorno','rma_troca')),
+  origem TEXT CHECK(origem IN ('compra','venda','ajuste','rma_retorno','rma_troca','ajuste_edit_prod','venda_edit')),
   ref_id INTEGER, usuario_id INTEGER,
   FOREIGN KEY(product_id) REFERENCES products(id),
   FOREIGN KEY(usuario_id) REFERENCES users(id)


### PR DESCRIPTION
## Summary
- add optional CSRF protection, SKU helper utilities, and development diagnostics routes
- migrate stock_moves schema to accept new origins and switch business logic to g.user_id while recomputing dashboard profits
- update init schema, README, and server startup block to default to port 5001 with free-port fallback

## Testing
- python -m compileall .
- export PORT=5001 && python app.py

------
https://chatgpt.com/codex/tasks/task_e_68cf07ae8fd08333aa28bb70208e1210