### PR TITLE
Update dashboard charts to use rendered data

### DIFF
--- a/StellaVisionMG_EXE_PATCH2_FIXED/StellaVisionMG/templates/dashboard.html
+++ b/StellaVisionMG_EXE_PATCH2_FIXED/StellaVisionMG/templates/dashboard.html
@@ -68,16 +68,28 @@
 <script>
 async function fetchJSON(url){ const r = await fetch(url); return await r.json(); }
 (async () => {
-  const charts = await fetchJSON("{{ url_for('api_graficos') }}{{ '?' + request.query_string.decode() if request.query_string else '' }}");
-  // Top10
-  const ctx1 = document.getElementById('chartTop10'); 
+  const top10Labels = {{ rows|map(attribute='nome')|list|tojson }};
+  const top10Values = {{ rows|map(attribute='lucro_liquido')|list|tojson }};
+  const vendasDiaLabels = {{ chart_labels|tojson }};
+  const vendasDiaValues = {{ chart_values|tojson }};
+
+  const ctx1 = document.getElementById('chartTop10');
   new Chart(ctx1, {
     type: 'bar',
-    data: { labels: charts.top10.labels, datasets: [{ label: charts.top10.label, data: charts.top10.values }] },
+    data: { labels: top10Labels, datasets: [{ label: 'Lucro líquido (R$)', data: top10Values }] },
     options: { responsive:true, plugins:{ legend:{ display:false } } }
   });
+
+  const ctx4 = document.getElementById('chartVendasDia');
+  new Chart(ctx4, {
+    type: 'line',
+    data: { labels: vendasDiaLabels, datasets: [{ label: 'Lucro líquido diário (R$)', data: vendasDiaValues }] },
+    options: { responsive:true }
+  });
+
+  const charts = await fetchJSON("{{ url_for('api_graficos') }}{{ '?' + request.query_string.decode() if request.query_string else '' }}");
   // Pie Categoria
-  const ctx2 = document.getElementById('chartPieCategoria'); 
+  const ctx2 = document.getElementById('chartPieCategoria');
   new Chart(ctx2, {
     type: 'pie',
     data: { labels: charts.categoria.labels, datasets: [{ data: charts.categoria.values }] },
@@ -89,13 +101,6 @@ async function fetchJSON(url){ const r = await fetch(url); return await r.json()
     type: 'bar',
     data: { labels: charts.margem_categoria.labels, datasets: [{ label: 'Margem %', data: charts.margem_categoria.values }] },
     options: { responsive:true, plugins:{ legend:{ display:false } } }
-  });
-  // Vendas por dia
-  const ctx4 = document.getElementById('chartVendasDia');
-  new Chart(ctx4, {
-    type: 'line',
-    data: { labels: charts.vendas_dia.labels, datasets: [{ label: 'Faturamento Diário (R$)', data: charts.vendas_dia.values }] },
-    options: { responsive:true }
   });
   // Cidades
   const ctx5 = document.getElementById('chartCidades');


### PR DESCRIPTION
## Summary
- feed the Top 10 chart directly from the server-rendered lucro líquido rows
- display the lucro líquido daily totals using the labels/values passed by the dashboard view
- keep the API fetch only for the remaining charts now that top 10 and vendas use server data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf131aa17c83338efba8cf950ae496